### PR TITLE
Typo fix

### DIFF
--- a/design_pattern_decisions.md
+++ b/design_pattern_decisions.md
@@ -12,7 +12,7 @@
 
 It prevents store from re-entrancy and DoS attacks.
 
-## Events and Loggging
+## Events and Logging
 
 Every time a user is created or updated or deleted or a donation is made and event is fired which can be catched at the frontend to make it more interactive and improve the UX.
 


### PR DESCRIPTION
# Fix Typo in Documentation  

## Description  
This PR corrects a minor typo in a section heading. **"Loggging"** was corrected to **"Logging"** for accuracy.  

## Changes Made  
- Fixed typo: "Loggging" → "Logging"  

